### PR TITLE
New function subed-mpv-play-video-from-url

### DIFF
--- a/subed/subed-mpv.el
+++ b/subed/subed-mpv.el
@@ -335,6 +335,23 @@ See \"List of events\" in mpv(1)."
          (or (file-directory-p filepath)
              (member (file-name-extension filename) subed-video-extensions)))))
 
+(defun subed-mpv-play-video-from-url (url)
+  "Open video file from URL in mpv."
+  (interactive "MURL: ")
+  (when (subed-mpv--server-started-p)
+    (subed-mpv-kill))
+  (when (apply #'subed-mpv--server-start subed-mpv-arguments)
+      (subed-debug "Opening video from URL: %s" url)
+      (subed-mpv--client-connect subed-mpv--retry-delays)
+      (subed-mpv--client-send `(loadfile ,url replace))
+      ;; mpv won't add the subtitles if the file doesn't exist yet, so we add it
+      ;; via after-save-hook.
+      (if (file-exists-p (buffer-file-name))
+          (subed-mpv-add-subtitles (buffer-file-name))
+        (add-hook 'after-save-hook #'subed-mpv--add-subtitle-after-first-save :append :local))
+      (subed-mpv--client-send `(observe_property 1 time-pos))
+      (subed-mpv-playback-speed subed-playback-speed-while-not-typing)))
+
 (defun subed-mpv-find-video (file)
   "Open video file FILE in mpv.
 

--- a/subed/subed.el
+++ b/subed/subed.el
@@ -59,6 +59,7 @@
     (define-key subed-mode-map (kbd "M-SPC") #'subed-mpv-toggle-pause)
     (define-key subed-mode-map (kbd "C-c C-d") #'subed-toggle-debugging)
     (define-key subed-mode-map (kbd "C-c C-v") #'subed-mpv-find-video)
+    (define-key subed-mode-map (kbd "C-c C-u") #'subed-mpv-play-video-from-url)
     (define-key subed-mode-map (kbd "C-c C-p") #'subed-toggle-pause-while-typing)
     (define-key subed-mode-map (kbd "C-c C-l") #'subed-toggle-loop-over-current-subtitle)
     (define-key subed-mode-map (kbd "C-c C-r") #'subed-toggle-replay-adjusted-subtitle)


### PR DESCRIPTION
* subed/subed-mpv.el: New function subed-mpv-play-video-from-url.
* subed/subed.el: Bind C-c C-w (mnemonic: web?) to
  subed-mpv-play-video-from-url. The main differences are that it
  doesn't complete or expand filenames.

As it turns out, MPV does the Right Thing when given a .webm URL, so people can use a URL as a video reference and all the usual synchronization just works.