### PR TITLE
Merge with next, previous

### DIFF
--- a/subed/subed-common.el
+++ b/subed/subed-common.el
@@ -627,8 +627,9 @@ following manner:
   "Merge the current subtitle with the previous subtitle.
 Update the end timestamp accordingly."
   (interactive)
-  (subed-backward-subtitle-id)
-  (subed-merge-with-next))
+  (if (subed-backward-subtitle-id)
+      (subed-merge-with-next)
+    (error "No previous subtitle to merge into")))
 
 ;;; Replay time-adjusted subtitle
 

--- a/subed/subed-common.el
+++ b/subed/subed-common.el
@@ -621,6 +621,14 @@ following manner:
     (subed-regenerate-ids-soon))
   (point))
 
+;;; Merging
+
+(defun subed-merge-with-previous ()
+  "Merge the current subtitle with the previous subtitle.
+Update the end timestamp accordingly."
+  (interactive)
+  (subed-backward-subtitle-id)
+  (subed-merge-with-next))
 
 ;;; Replay time-adjusted subtitle
 

--- a/subed/subed-srt.el
+++ b/subed/subed-srt.el
@@ -423,17 +423,19 @@ Return new point."
   "Merge the current subtitle with the next subtitle.
 Update the end timestamp accordingly."
   (interactive)
-  (subed-srt--jump-to-subtitle-end)
   (save-excursion
+    (subed-srt--jump-to-subtitle-end)
     (let ((pos (point)) new-end)
-      (subed-srt--forward-subtitle-time-stop)
-      (when (looking-at subed-srt--regexp-timestamp)
-        (setq new-end (subed-srt--timestamp-to-msecs (match-string 0))))
-      (subed-srt--jump-to-subtitle-text)
-      (delete-region pos (point))
-      (insert "\n")
-      (subed-srt--set-subtitle-time-stop new-end)))
-  (subed-srt--regenerate-ids-soon))
+      (if (subed-srt--forward-subtitle-time-stop)
+          (progn
+            (when (looking-at subed-srt--regexp-timestamp)
+              (setq new-end (subed-srt--timestamp-to-msecs (match-string 0))))
+            (subed-srt--jump-to-subtitle-text)
+            (delete-region pos (point))
+            (insert "\n")
+            (subed-srt--set-subtitle-time-stop new-end)
+            (subed-srt--regenerate-ids-soon))
+        (error "No subtitle to merge into")))))
 
 ;;; Maintenance
 

--- a/subed/subed-srt.el
+++ b/subed/subed-srt.el
@@ -419,6 +419,21 @@ Return new point."
     (delete-region beg end))
   (subed-srt--regenerate-ids-soon))
 
+(defun subed-srt--merge-with-next ()
+  "Merge the current subtitle with the next subtitle.
+Update the end timestamp accordingly."
+  (interactive)
+  (subed-srt--jump-to-subtitle-end)
+  (save-excursion
+    (let ((pos (point)) new-end)
+      (subed-srt--forward-subtitle-time-stop)
+      (when (looking-at subed-srt--regexp-timestamp)
+        (setq new-end (subed-srt--timestamp-to-msecs (match-string 0))))
+      (subed-srt--jump-to-subtitle-text)
+      (delete-region pos (point))
+      (insert "\n")
+      (subed-srt--set-subtitle-time-stop new-end)))
+  (subed-srt--regenerate-ids-soon))
 
 ;;; Maintenance
 

--- a/subed/subed-vtt.el
+++ b/subed/subed-vtt.el
@@ -414,8 +414,22 @@ Return new point."
                                   (subed-vtt--backward-subtitle-end)
                                   (1+ (point)))
               end (save-excursion (goto-char (point-max)))))
-    (delete-region beg end))
-  (subed-vtt--regenerate-ids-soon))
+    (delete-region beg end)))
+
+(defun subed-vtt--merge-with-next ()
+  "Merge the current subtitle with the next subtitle.
+Update the end timestamp accordingly."
+  (interactive)
+  (subed-vtt--jump-to-subtitle-end)
+  (save-excursion
+    (let ((pos (point)) new-end)
+      (subed-vtt--forward-subtitle-time-stop)
+      (when (looking-at subed-vtt--regexp-timestamp)
+        (setq new-end (subed-vtt--timestamp-to-msecs (match-string 0))))
+      (subed-vtt--jump-to-subtitle-text)
+      (delete-region pos (point))
+      (insert "\n")
+      (subed-vtt--set-subtitle-time-stop new-end))))
 
 
 ;;; Maintenance

--- a/subed/subed-vtt.el
+++ b/subed/subed-vtt.el
@@ -421,16 +421,18 @@ Return new point."
   "Merge the current subtitle with the next subtitle.
 Update the end timestamp accordingly."
   (interactive)
-  (subed-vtt--jump-to-subtitle-end)
   (save-excursion
+    (subed-vtt--jump-to-subtitle-end)
     (let ((pos (point)) new-end)
-      (subed-vtt--forward-subtitle-time-stop)
-      (when (looking-at subed-vtt--regexp-timestamp)
-        (setq new-end (subed-vtt--timestamp-to-msecs (match-string 0))))
-      (subed-vtt--jump-to-subtitle-text)
-      (delete-region pos (point))
-      (insert "\n")
-      (subed-vtt--set-subtitle-time-stop new-end))))
+      (if (subed-vtt--forward-subtitle-time-stop)
+          (progn
+            (when (looking-at subed-vtt--regexp-timestamp)
+              (setq new-end (subed-vtt--timestamp-to-msecs (match-string 0))))
+            (subed-vtt--jump-to-subtitle-text)
+            (delete-region pos (point))
+            (insert "\n")
+            (subed-vtt--set-subtitle-time-stop new-end))
+        (error "No subtitle to merge into")))))
 
 
 ;;; Maintenance

--- a/subed/subed.el
+++ b/subed/subed.el
@@ -55,6 +55,7 @@
     (define-key subed-mode-map (kbd "M-i") #'subed-insert-subtitle)
     (define-key subed-mode-map (kbd "C-M-i") #'subed-insert-subtitle-adjacent)
     (define-key subed-mode-map (kbd "M-k") #'subed-kill-subtitle)
+    (define-key subed-mode-map (kbd "M-m") #'subed-merge-with-next)
     (define-key subed-mode-map (kbd "M-s") #'subed-sort)
     (define-key subed-mode-map (kbd "M-SPC") #'subed-mpv-toggle-pause)
     (define-key subed-mode-map (kbd "C-c C-d") #'subed-toggle-debugging)
@@ -96,7 +97,7 @@
         "forward-subtitle-time-start" "backward-subtitle-time-start"
         "forward-subtitle-time-stop" "backward-subtitle-time-stop"
         "set-subtitle-time-start" "set-subtitle-time-stop"
-        "prepend-subtitle" "append-subtitle" "kill-subtitle"
+        "prepend-subtitle" "append-subtitle" "kill-subtitle" "merge-with-next"
         "regenerate-ids" "regenerate-ids-soon"
         "sanitize" "validate" "sort"))
 

--- a/subed/subed.el
+++ b/subed/subed.el
@@ -56,6 +56,7 @@
     (define-key subed-mode-map (kbd "C-M-i") #'subed-insert-subtitle-adjacent)
     (define-key subed-mode-map (kbd "M-k") #'subed-kill-subtitle)
     (define-key subed-mode-map (kbd "M-m") #'subed-merge-with-next)
+    (define-key subed-mode-map (kbd "M-M") #'subed-merge-with-previous)
     (define-key subed-mode-map (kbd "M-s") #'subed-sort)
     (define-key subed-mode-map (kbd "M-SPC") #'subed-mpv-toggle-pause)
     (define-key subed-mode-map (kbd "C-c C-d") #'subed-toggle-debugging)


### PR DESCRIPTION
As suggested by alphapapa, this one adds a command to merge the current subtitle with the next one, using the next one's ending timestamp as the new ending timestamp. There's also a command to merge with the previous one. It seems to work for SRT files with your code, and it'll work for .vtt files with the code for the other pull requests. What do you think? I wasn't sure about the keybinding. Is there a different one that might make sense? =)