### PR TITLE
subed-vtt: Fix syncing point with player

### DIFF
--- a/subed/subed-vtt.el
+++ b/subed/subed-vtt.el
@@ -483,8 +483,7 @@ Return new point."
       (save-match-data
         (let ((orig-point (point)))
           (goto-char (point-min))
-          (while (and (re-search-forward (format "\\(%s[[^\\']]\\|\\`\\)" subed-vtt--regexp-separator) nil t)
-                      (looking-at "[[:alnum:]]"))
+          (while (and (re-search-forward (format "\\(%s[[^\\']]\\|\\`\\)%s" subed-vtt--regexp-separator subed-vtt--regexp-timestamp) nil t) (goto-char (match-beginning 2)))
             ;; This regex is stricter than `subed-vtt--regexp-timestamp'
             (unless (looking-at "^[0-9]\\{2\\}:[0-9]\\{2\\}:[0-9]\\{2\\}\\.[0-9]\\{3\\}")
               (error "Found invalid start time: %S"  (substring (or (thing-at-point 'line :no-properties) "\n") 0 -1)))

--- a/subed/subed-vtt.el
+++ b/subed/subed-vtt.el
@@ -179,7 +179,7 @@ Return point or nil if point is still on the same subtitle.
 See also `subed-vtt--subtitle-id-at-msecs'."
   (let ((current-sub-id (subed-vtt--subtitle-id))
         (target-sub-id (subed-vtt--subtitle-id-at-msecs msecs)))
-    (when (and target-sub-id current-sub-id (not (= target-sub-id current-sub-id)))
+    (when (and target-sub-id current-sub-id (not (equal target-sub-id current-sub-id)))
       (subed-vtt--jump-to-subtitle-id target-sub-id))))
 
 (defun subed-vtt--jump-to-subtitle-text-at-msecs (msecs)

--- a/subed/subed-vtt.el
+++ b/subed/subed-vtt.el
@@ -232,7 +232,7 @@ can be found."
       ;; `subed-vtt--regexp-separator' here because if subtitle text is empty,
       ;; it may be the only empty line in the separator, i.e. there's only one
       ;; "\n".
-      (let ((regex (concat "\\([[:blank:]]*\n+[0-9]+\n\\|\\([[:blank:]]*\n*\\)\\'\\)")))
+      (let ((regex (concat "\\([[:blank:]]*\n+" subed-vtt--regexp-timestamp "\\|\\([[:blank:]]*\n*\\)\\'\\)")))
         (when (re-search-forward regex nil t)
           (goto-char (match-beginning 0))))
       (unless (= (point) orig-point)
@@ -252,7 +252,7 @@ Return point or nil if there is no previous subtitle."
   (interactive)
   (let ((orig-point (point)))
     (when (subed-vtt--jump-to-subtitle-id)
-      (if (re-search-backward (concat "\\(" subed-vtt--regexp-separator "\\|\\`[[:space:]]*\\)" "\\([0-9]+\\)\n") nil t)
+      (if (re-search-backward (concat "\\(" subed-vtt--regexp-separator "\\|\\`[[:space:]]*\\)\\(" subed-vtt--regexp-timestamp "\\)") nil t)
           (progn
             (goto-char (match-beginning 2))
             (point))
@@ -369,7 +369,7 @@ Return new point."
   (subed-vtt--jump-to-subtitle-id)
   (insert (subed-vtt--make-subtitle id start stop text))
   (save-match-data
-    (when (looking-at "\\([[:space:]]*\\|^\\)[0-9]+$")
+    (when (looking-at (concat "\\([[:space:]]*\\|^\\)" subed-vtt--regexp-timestamp))
       (insert "\n")))
   (forward-line -2)
   (subed-vtt--jump-to-subtitle-text))

--- a/subed/subed-vtt.el
+++ b/subed/subed-vtt.el
@@ -148,14 +148,14 @@ If SUB-ID is not given, use subtitle on point."
   "Move to the ID of a subtitle and return point.
 If SUB-ID is not given, focus the current subtitle's ID.
 Return point or nil if no subtitle ID could be found.
-WebVTT doesn't use IDs, so we use the starting timestamp instead"
+WebVTT doesn't use IDs, so we use the starting timestamp instead."
   (interactive)
   (save-match-data
-    (if sub-id
+    (if (stringp sub-id)
         ;; Look for a line that contains only the ID, preceded by one or more
         ;; blank lines or the beginning of the buffer.
         (let* ((orig-point (point))
-               (regex (concat "\\(" subed-srt--regexp-separator "\\|\\`\\)\\(" (regexp-quote (string-to-number sub-id)) "\\)"))
+               (regex (concat "\\(" subed-srt--regexp-separator "\\|\\`\\)\\(" (regexp-quote sub-id) "\\)"))
                (match-found (progn (goto-char (point-min))
                                    (re-search-forward regex nil t))))
           (if match-found
@@ -414,8 +414,7 @@ Return new point."
                                   (subed-vtt--backward-subtitle-end)
                                   (1+ (point)))
               end (save-excursion (goto-char (point-max)))))
-    (delete-region beg end))
-  (subed-vtt--regenerate-ids-soon))
+    (delete-region beg end)))
 
 
 ;;; Maintenance
@@ -517,8 +516,7 @@ Return new point."
                 ;; endrecfun (move to end of current record/subtitle)
                 #'subed-vtt--jump-to-subtitle-end
                 ;; startkeyfun (return sort value of current record/subtitle)
-                #'subed-vtt--subtitle-msecs-start))
-    (subed-vtt--regenerate-ids)))
+                #'subed-vtt--subtitle-msecs-start))))
 
 (defun subed-vtt--init ()
   "This function is called when subed-mode is entered for a SRT file."

--- a/subed/subed.el
+++ b/subed/subed.el
@@ -36,6 +36,7 @@
 (require 'subed-debug)
 (require 'subed-common)
 (require 'subed-srt)
+(require 'subed-vtt)
 (require 'subed-mpv)
 
 (setq subed-mode-map


### PR DESCRIPTION
* subed/subed-vtt.el (subed-vtt--jump-to-subtitle-id-at-msecs): Use
equal instead of = when comparing timestamp. This allows syncing point with player.