### PR TITLE
Fix separator search in subed-srt--validate

### DIFF
--- a/subed/subed-srt.el
+++ b/subed/subed-srt.el
@@ -519,7 +519,7 @@ scheduled call is canceled and another call is scheduled in
               (error "Found invalid subtitle ID: %S" (substring (or (thing-at-point 'line :no-properties) "\n") 0 -1)))
             (forward-line)
             ;; This regex is stricter than `subed-srt--regexp-timestamp'
-            (unless (looking-at "^[0-9]\\{2\\}:[0-9]\\{2\\}:[0-9]\\{2\\},[0-9]\\{3\\}")
+            (unless (looking-at "^[0-9]\\{2\\}:[0-9]\\{2\\}:[0-9]\\{2\\},[0-9]\\{,3\\}")
               (error "Found invalid start time: %S"  (substring (or (thing-at-point 'line :no-properties) "\n") 0 -1)))
             (when (re-search-forward "[[:blank:]]" (point-at-eol) t)
               (goto-char (match-beginning 0)))
@@ -529,7 +529,7 @@ scheduled call is canceled and another call is scheduled in
             (condition-case nil
                 (forward-char 5)
               (error nil))
-            (unless (looking-at "[0-9]\\{2\\}:[0-9]\\{2\\}:[0-9]\\{2\\},[0-9]\\{3\\}$")
+            (unless (looking-at "[0-9]\\{2\\}:[0-9]\\{2\\}:[0-9]\\{2\\},[0-9]\\{,3\\}$")
               (error "Found invalid stop time: %S" (substring (or (thing-at-point 'line :no-properties) "\n") 0 -1))))
           (goto-char orig-point))))))
 

--- a/subed/subed-srt.el
+++ b/subed/subed-srt.el
@@ -513,7 +513,7 @@ scheduled call is canceled and another call is scheduled in
       (save-match-data
         (let ((orig-point (point)))
           (goto-char (point-min))
-          (while (and (re-search-forward (format "\\(%s[[^\\']]\\|\\`\\)" subed-srt--regexp-separator) nil t)
+          (while (and (re-search-forward (format "\\(%s\\|\\`\\)" subed-srt--regexp-separator) nil t)
                       (looking-at "[[:alnum:]]"))
             (unless (looking-at "^[0-9]+$")
               (error "Found invalid subtitle ID: %S" (substring (or (thing-at-point 'line :no-properties) "\n") 0 -1)))

--- a/tests/test-subed-srt.el
+++ b/tests/test-subed-srt.el
@@ -1238,6 +1238,15 @@ Baz.
       (expect (subed-srt--validate) :to-throw
               'error '("Found invalid separator between start and stop time: \"00:01:01,000 -->00:01:05,123\""))
       (expect (point) :to-equal 15)))
+  (it "reports invalid start time in later entries."
+    (with-temp-srt-buffer
+      (insert mock-srt-data)
+      (subed-srt--jump-to-subtitle-time-start 3)
+      (forward-char 3)
+      (insert "##")
+      (expect (subed-srt--validate) :to-throw
+              'error '("Found invalid start time: \"00:##03:03,45 --> 00:03:15,5\""))
+      (expect (point) :to-equal 79)))
   (it "does not report error when last subtitle text is empty."
     (with-temp-srt-buffer
       (insert mock-srt-data)


### PR DESCRIPTION
Before this fix, subed-srt--validate was not scanning most of the
file.  The reason is that [[^\\']] matches the literal characters [,
^, \, or ', followed by a ].  The intent was probably to reject
end-of-buffer, but that's already handled by the subsequent
looking-at.