### PR TITLE
New commands: subed-merge-with-next, subed-merge-with-previous

### DIFF
--- a/subed/subed-common.el
+++ b/subed/subed-common.el
@@ -621,6 +621,15 @@ following manner:
     (subed-regenerate-ids-soon))
   (point))
 
+;;; Merging
+
+(defun subed-merge-with-previous ()
+  "Merge the current subtitle with the previous subtitle.
+Update the end timestamp accordingly."
+  (interactive)
+  (if (subed-backward-subtitle-id)
+      (subed-merge-with-next)
+    (error "No previous subtitle to merge into")))
 
 ;;; Replay time-adjusted subtitle
 

--- a/subed/subed-srt.el
+++ b/subed/subed-srt.el
@@ -419,6 +419,23 @@ Return new point."
     (delete-region beg end))
   (subed-srt--regenerate-ids-soon))
 
+(defun subed-srt--merge-with-next ()
+  "Merge the current subtitle with the next subtitle.
+Update the end timestamp accordingly."
+  (interactive)
+  (save-excursion
+    (subed-srt--jump-to-subtitle-end)
+    (let ((pos (point)) new-end)
+      (if (subed-srt--forward-subtitle-time-stop)
+          (progn
+            (when (looking-at subed-srt--regexp-timestamp)
+              (setq new-end (subed-srt--timestamp-to-msecs (match-string 0))))
+            (subed-srt--jump-to-subtitle-text)
+            (delete-region pos (point))
+            (insert "\n")
+            (subed-srt--set-subtitle-time-stop new-end)
+            (subed-srt--regenerate-ids-soon))
+        (error "No subtitle to merge into")))))
 
 ;;; Maintenance
 

--- a/subed/subed-vtt.el
+++ b/subed/subed-vtt.el
@@ -416,6 +416,23 @@ Return new point."
               end (save-excursion (goto-char (point-max)))))
     (delete-region beg end)))
 
+(defun subed-vtt--merge-with-next ()
+  "Merge the current subtitle with the next subtitle.
+Update the end timestamp accordingly."
+  (interactive)
+  (save-excursion
+    (subed-vtt--jump-to-subtitle-end)
+    (let ((pos (point)) new-end)
+      (if (subed-vtt--forward-subtitle-time-stop)
+          (progn
+            (when (looking-at subed-vtt--regexp-timestamp)
+              (setq new-end (subed-vtt--timestamp-to-msecs (match-string 0))))
+            (subed-vtt--jump-to-subtitle-text)
+            (delete-region pos (point))
+            (insert "\n")
+            (subed-vtt--set-subtitle-time-stop new-end))
+        (error "No subtitle to merge into")))))
+
 
 ;;; Maintenance
 

--- a/subed/subed.el
+++ b/subed/subed.el
@@ -56,6 +56,8 @@
     (define-key subed-mode-map (kbd "M-i") #'subed-insert-subtitle)
     (define-key subed-mode-map (kbd "C-M-i") #'subed-insert-subtitle-adjacent)
     (define-key subed-mode-map (kbd "M-k") #'subed-kill-subtitle)
+    (define-key subed-mode-map (kbd "M-m") #'subed-merge-with-next)
+    (define-key subed-mode-map (kbd "M-M") #'subed-merge-with-previous)
     (define-key subed-mode-map (kbd "M-s") #'subed-sort)
     (define-key subed-mode-map (kbd "M-SPC") #'subed-mpv-toggle-pause)
     (define-key subed-mode-map (kbd "C-c C-d") #'subed-toggle-debugging)
@@ -98,7 +100,7 @@
         "forward-subtitle-time-start" "backward-subtitle-time-start"
         "forward-subtitle-time-stop" "backward-subtitle-time-stop"
         "set-subtitle-time-start" "set-subtitle-time-stop"
-        "prepend-subtitle" "append-subtitle" "kill-subtitle"
+        "prepend-subtitle" "append-subtitle" "kill-subtitle" "merge-with-next"
         "regenerate-ids" "regenerate-ids-soon"
         "sanitize" "validate" "sort"))
 


### PR DESCRIPTION
* subed/subed.el (subed-mode-map): Bind M-m to subed-merge-with-next.
  Bind M-M to subed-merge-with-previous
  (subed--generic-function-suffixes): Add generic merge-with-next.
* subed/subed-common.el (subed-merge-with-previous): New command.
* subed/subed-srt.el (subed-srt--merge-with-next): New command.
* subed/subed-vtt.el (subed-vtt--merge-with-next): New command.

All right, this should be just the diff for merge with next/previous that can be applied to your sacha branch. =)