### PR TITLE
Add video movement per frame

### DIFF
--- a/subed/subed-mpv.el
+++ b/subed/subed-mpv.el
@@ -321,14 +321,20 @@ See \"List of events\" in mpv(1)."
       (subed-mpv-jump cur-sub-start))))
 
 (defun subed-mpv-frame-step ()
-  "Step one frame forward."
+  "Step one frame forward.
+Set up keybindings so that repeatedly pressing `,' and `.' moves
+by frames until any other key is pressed."
   (interactive)
-  (subed-mpv--client-send `(frame-step)))
+  (subed-mpv--client-send `(frame-step))
+  (set-transient-map subed-mpv-frame-step-map))
 
 (defun subed-mpv-frame-back-step ()
-  "Step one frame backward."
+  "Step one frame backward.
+Set up keybindings so that repeatedly pressing `,' and `.' moves
+by frames until any other key is pressed."
   (interactive)
-  (subed-mpv--client-send `(frame-back-step)))
+  (subed-mpv--client-send `(frame-back-step))
+  (set-transient-map subed-mpv-frame-step-map))
 
 (defun subed-mpv-add-subtitles (file)
   "Load FILE as subtitles in mpv."

--- a/subed/subed-mpv.el
+++ b/subed/subed-mpv.el
@@ -320,6 +320,16 @@ See \"List of events\" in mpv(1)."
       (subed-debug "Seeking player to focused subtitle: %S" cur-sub-start)
       (subed-mpv-jump cur-sub-start))))
 
+(defun subed-mpv-frame-step ()
+  "Step one frame forward."
+  (interactive)
+  (subed-mpv--client-send `(frame-step)))
+
+(defun subed-mpv-frame-back-step ()
+  "Step one frame backward."
+  (interactive)
+  (subed-mpv--client-send `(frame-back-step)))
+
 (defun subed-mpv-add-subtitles (file)
   "Load FILE as subtitles in mpv."
   (subed-mpv--client-send `(sub-add ,file select)))

--- a/subed/subed.el
+++ b/subed/subed.el
@@ -39,6 +39,13 @@
 (require 'subed-vtt)
 (require 'subed-mpv)
 
+(defconst subed-mpv-frame-step-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map "." #'subed-mpv-frame-step)
+    (define-key map "," #'subed-mpv-frame-back-step)
+    map)
+  "A keymap for stepping the video by frames.")
+
 (setq subed-mode-map
   (let ((subed-mode-map (make-keymap)))
     (define-key subed-mode-map (kbd "M-n") #'subed-forward-subtitle-text)
@@ -64,8 +71,7 @@
     (define-key subed-mode-map (kbd "C-c C-d") #'subed-toggle-debugging)
     (define-key subed-mode-map (kbd "C-c C-v") #'subed-mpv-find-video)
     (define-key subed-mode-map (kbd "C-c C-u") #'subed-mpv-play-video-from-url)
-    (define-key subed-mode-map (kbd "C-c <right>") #'subed-mpv-frame-step)
-    (define-key subed-mode-map (kbd "C-c <left>") #'subed-mpv-frame-back-step)
+    (define-key subed-mode-map (kbd "C-c C-f") subed-mpv-frame-step-map)
     (define-key subed-mode-map (kbd "C-c C-p") #'subed-toggle-pause-while-typing)
     (define-key subed-mode-map (kbd "C-c C-l") #'subed-toggle-loop-over-current-subtitle)
     (define-key subed-mode-map (kbd "C-c C-r") #'subed-toggle-replay-adjusted-subtitle)

--- a/subed/subed.el
+++ b/subed/subed.el
@@ -64,6 +64,8 @@
     (define-key subed-mode-map (kbd "C-c C-d") #'subed-toggle-debugging)
     (define-key subed-mode-map (kbd "C-c C-v") #'subed-mpv-find-video)
     (define-key subed-mode-map (kbd "C-c C-u") #'subed-mpv-play-video-from-url)
+    (define-key subed-mode-map (kbd "C-c <right>") #'subed-mpv-frame-step)
+    (define-key subed-mode-map (kbd "C-c <left>") #'subed-mpv-frame-back-step)
     (define-key subed-mode-map (kbd "C-c C-p") #'subed-toggle-pause-while-typing)
     (define-key subed-mode-map (kbd "C-c C-l") #'subed-toggle-loop-over-current-subtitle)
     (define-key subed-mode-map (kbd "C-c C-r") #'subed-toggle-replay-adjusted-subtitle)


### PR DESCRIPTION
Again, I'm open to suggestions re: keybindings. This feature is useful when you want the subtitle to appear (or hide) at some exact moment, e.g. when some text appears on the screen.