### PR TITLE
Keep track of video being played

### DIFF
--- a/subed/subed-config.el
+++ b/subed/subed-config.el
@@ -88,7 +88,7 @@
   :type 'hook
   :group 'subed)
 
-(defcustom subed-video-extensions '("mkv" "mp4" "webm" "avi" "ts" "ogv")
+(defcustom subed-video-extensions '("mkv" "mp4" "webm" "avi" "ts" "ogv" "wav" "ogg" "mp3")
   "Video file name extensions."
   :type 'list
   :group 'subed)

--- a/subed/subed-mpv.el
+++ b/subed/subed-mpv.el
@@ -47,6 +47,8 @@
                                            subed-mpv-jump-to-current-subtitle)
   "Functions to call when mpv has loaded a file and starts playing.")
 
+(defvar-local subed-mpv-video-file nil "Current file.")
+
 (defvar-local subed-mpv--server-proc nil
   "Running mpv process.")
 
@@ -315,6 +317,7 @@ See \"List of events\" in mpv(1)."
 
 (defun subed-mpv-jump-to-current-subtitle ()
   "Move playback position to start of currently focused subtitle if possible."
+  (interactive)
   (let ((cur-sub-start (subed-subtitle-msecs-start)))
     (when cur-sub-start
       (subed-debug "Seeking player to focused subtitle: %S" cur-sub-start)
@@ -381,6 +384,7 @@ hosting providers."
 Video files are expected to have any of the extensions listed in
 `subed-video-extensions'."
   (interactive (list (read-file-name "Find video: " nil nil t nil #'subed-mpv--is-video-file-p)))
+  (setq subed-mpv-video-file (expand-file-name file))
   (subed-mpv--play (expand-file-name file)))
 
 (defun subed-mpv--add-subtitle-after-first-save ()

--- a/subed/subed-mpv.el
+++ b/subed/subed-mpv.el
@@ -317,7 +317,6 @@ See \"List of events\" in mpv(1)."
 
 (defun subed-mpv-jump-to-current-subtitle ()
   "Move playback position to start of currently focused subtitle if possible."
-  (interactive)
   (let ((cur-sub-start (subed-subtitle-msecs-start)))
     (when cur-sub-start
       (subed-debug "Seeking player to focused subtitle: %S" cur-sub-start)
@@ -376,6 +375,7 @@ See the mpv manual for a list of supported URL types.  If you
 have youtube-dl installed, mpv can open videos from a variety of
 hosting providers."
   (interactive "MURL: ")
+  (setq subed-mpv-video-file url)
   (subed-mpv--play url))
 
 (defun subed-mpv-find-video (file)

--- a/subed/subed.el
+++ b/subed/subed.el
@@ -70,7 +70,6 @@
     (define-key subed-mode-map (kbd "M-.") #'subed-split-subtitle)
     (define-key subed-mode-map (kbd "M-s") #'subed-sort)
     (define-key subed-mode-map (kbd "M-SPC") #'subed-mpv-toggle-pause)
-    (define-key subed-mode-map (kbd "M-j") #'subed-mpv-jump-to-current-subtitle)
     (define-key subed-mode-map (kbd "C-c C-d") #'subed-toggle-debugging)
     (define-key subed-mode-map (kbd "C-c C-v") #'subed-mpv-find-video)
     (define-key subed-mode-map (kbd "C-c C-u") #'subed-mpv-play-video-from-url)

--- a/subed/subed.el
+++ b/subed/subed.el
@@ -70,6 +70,7 @@
     (define-key subed-mode-map (kbd "M-.") #'subed-split-subtitle)
     (define-key subed-mode-map (kbd "M-s") #'subed-sort)
     (define-key subed-mode-map (kbd "M-SPC") #'subed-mpv-toggle-pause)
+    (define-key subed-mode-map (kbd "M-j") #'subed-mpv-jump-to-current-subtitle)
     (define-key subed-mode-map (kbd "C-c C-d") #'subed-toggle-debugging)
     (define-key subed-mode-map (kbd "C-c C-v") #'subed-mpv-find-video)
     (define-key subed-mode-map (kbd "C-c C-u") #'subed-mpv-play-video-from-url)


### PR DESCRIPTION
This makes it easier for other code to get the currently-playing file.

* subed/subed-mpv.el (subed-mpv-video-file): New variable.
  (subed-mpv-find-video): Keep track of file.
  (subed-mpv-play-video-from-url): Keep track of URL.