### PR TITLE
Make subed-mpv-jump-to-current-subtitle interactive

### DIFF
--- a/subed/subed-mpv.el
+++ b/subed/subed-mpv.el
@@ -315,6 +315,7 @@ See \"List of events\" in mpv(1)."
 
 (defun subed-mpv-jump-to-current-subtitle ()
   "Move playback position to start of currently focused subtitle if possible."
+  (interactive)
   (let ((cur-sub-start (subed-subtitle-msecs-start)))
     (when cur-sub-start
       (subed-debug "Seeking player to focused subtitle: %S" cur-sub-start)

--- a/subed/subed.el
+++ b/subed/subed.el
@@ -70,6 +70,7 @@
     (define-key subed-mode-map (kbd "M-.") #'subed-split-subtitle)
     (define-key subed-mode-map (kbd "M-s") #'subed-sort)
     (define-key subed-mode-map (kbd "M-SPC") #'subed-mpv-toggle-pause)
+    (define-key subed-mode-map (kbd "M-j") #'subed-mpv-jump-to-current-subtitle)
     (define-key subed-mode-map (kbd "C-c C-d") #'subed-toggle-debugging)
     (define-key subed-mode-map (kbd "C-c C-v") #'subed-mpv-find-video)
     (define-key subed-mode-map (kbd "C-c C-u") #'subed-mpv-play-video-from-url)


### PR DESCRIPTION
This is useful for manually looping over a subtitle.

* subed/subed-mpv.el (subed-mpv-jump-to-current-subtitle): Add
  interactive marker.
* subed/subed.el (subed-mode-map): Bind M-j to subed-mpv-jump-to-current-subtitle.