### PR TITLE
Check if subed--cps-overlay exists before trying to update it

### DIFF
--- a/subed/subed-common.el
+++ b/subed/subed-common.el
@@ -1286,12 +1286,13 @@ attribute(s)."
   "Update the CPS overlay.
 This accepts and ignores any number of arguments so that it can
 be run in `after-change-functions'."
-  (let ((cps (subed-calculate-cps)))
-    (when (numberp cps)
-      (overlay-put
-       subed--cps-overlay
-       'after-string
-       (propertize (format " %.1f CPS" cps) 'face 'shadow 'display '(height 0.9))))))
+  (when (overlayp subed--cps-overlay)
+    (let ((cps (subed-calculate-cps)))
+      (when (numberp cps)
+        (overlay-put
+         subed--cps-overlay
+         'after-string
+         (propertize (format " %.1f CPS" cps) 'face 'shadow 'display '(height 0.9)))))))
 
 (provide 'subed-common)
 ;;; subed-common.el ends here


### PR DESCRIPTION
* subed/subed-common.el (subed--update-cps-overlay): Do this only if
  the overlay exists. This makes code work even if the overlay has not
  been created, as in the case of non-interactive use.