### PR TITLE
Make hours optional in VTT files, following the spec

### DIFF
--- a/subed/subed-vtt.el
+++ b/subed/subed-vtt.el
@@ -35,7 +35,7 @@
 
 (defconst subed-vtt-font-lock-keywords
   (list
-   '("[0-9]+:[0-9]+:[0-9]+\\.[0-9]+" . 'subed-vtt-time-face)
+   '("\\([0-9]+:\\)?[0-9]+:[0-9]+\\.[0-9]+" . 'subed-vtt-time-face)
    '(",[0-9]+ \\(-->\\) [0-9]+:" 1 'subed-vtt-time-separator-face t)
    '("^.*$" . 'subed-vtt-text-face))
   "Highlighting expressions for `subed-mode'.")
@@ -43,7 +43,7 @@
 
 ;;; Parsing
 
-(defconst subed-vtt--regexp-timestamp "\\([0-9]+\\):\\([0-9]+\\):\\([0-9]+\\)\\.\\([0-9]+\\)")
+(defconst subed-vtt--regexp-timestamp "\\(\\([0-9]+\\):\\)?\\([0-9]+\\):\\([0-9]+\\)\\.\\([0-9]+\\)")
 (defconst subed-vtt--regexp-separator "\\(?:[[:blank:]]*\n\\)+[[:blank:]]*\n")
 
 (defun subed-vtt--timestamp-to-msecs (time-string)
@@ -51,10 +51,10 @@
 Return nil if TIME-STRING doesn't match the pattern."
   (save-match-data
     (when (string-match subed-vtt--regexp-timestamp time-string)
-      (let ((hours (string-to-number (match-string 1 time-string)))
-            (mins  (string-to-number (match-string 2 time-string)))
-            (secs  (string-to-number (match-string 3 time-string)))
-            (msecs (string-to-number (subed--right-pad (match-string 4 time-string) 3 ?0))))
+      (let ((hours (string-to-number (or (match-string 2 time-string) "0")))
+            (mins  (string-to-number (match-string 3 time-string)))
+            (secs  (string-to-number (match-string 4 time-string)))
+            (msecs (string-to-number (subed--right-pad (match-string 5 time-string) 3 ?0))))
         (+ (* (truncate hours) 3600000)
            (* (truncate mins) 60000)
            (* (truncate secs) 1000)
@@ -170,7 +170,7 @@ WebVTT doesn't use IDs, so we use the starting timestamp instead."
         (when match-found
           (goto-char (match-beginning 2)))))
     ;; Make extra sure we're on a timestamp, return nil if we're not
-    (when (looking-at "^\\([0-9]+:[0-9]+:[0-9]+\\.[0-9]+\\)")
+    (when (looking-at "^\\(\\([0-9]+:\\)?[0-9]+:[0-9]+\\.[0-9]+\\)")
       (point))))
 
 (defun subed-vtt--jump-to-subtitle-id-at-msecs (msecs)

--- a/tests/test-subed-vtt.el
+++ b/tests/test-subed-vtt.el
@@ -39,6 +39,11 @@ Baz.
                                  (thing-at-point 'line)) :to-equal "00:03:03.45 --> 00:03:15.5\n")
          (expect (subed-vtt--subtitle-msecs-start) :to-equal (+ (* 3 60 1000) (*  3 1000) 450))
          (expect (subed-vtt--subtitle-msecs-stop)  :to-equal (+ (* 3 60 1000) (* 15 1000) 500))))
+      (it "handles lack of hours in milliseconds gracefully."
+        (with-temp-vtt-buffer
+         (insert "WEBVTT\n\n01:02.000 --> 03:04.000\nHello\n")
+         (expect (subed-vtt--subtitle-msecs-start) :to-equal (+ (* 1 60 1000) (* 2 1000)))
+         (expect (subed-vtt--subtitle-msecs-stop) :to-equal (+ (* 3 60 1000) (* 4 1000)))))
       (it "returns nil if time can't be found."
         (with-temp-vtt-buffer
          (expect (subed-vtt--subtitle-msecs-start) :to-be nil)


### PR DESCRIPTION
* subed/subed-vtt.el (subed-vtt-font-lock-keywords): Make hours optional.
  (subed-vtt--regexp-timestamp): Make hours optional.
  (subed-vtt--timestamp-to-msecs): Make hours optional.
  (subed-vtt--jump-to-subtitle-id): Make hours optional.
* tests/test-subed-vtt.el ("VTT"): Add test for optional hours.