### PR TITLE
Handle spaces in between VTT subtitles

### DIFF
--- a/subed/subed-vtt.el
+++ b/subed/subed-vtt.el
@@ -232,7 +232,7 @@ can be found."
       ;; `subed-vtt--regexp-separator' here because if subtitle text is empty,
       ;; it may be the only empty line in the separator, i.e. there's only one
       ;; "\n".
-      (let ((regex (concat "\\([[:blank:]]*\n+" subed-vtt--regexp-timestamp "\\|\\([[:blank:]]*\n*\\)\\'\\)")))
+      (let ((regex (concat "\\([[:blank:]]*\n\\)+\\(" subed-vtt--regexp-timestamp "\\)\\|\\([[:blank:]]*\n*\\)\\'")))
         (when (re-search-forward regex nil t)
           (goto-char (match-beginning 0))))
       (unless (= (point) orig-point)

--- a/tests/test-subed-vtt.el
+++ b/tests/test-subed-vtt.el
@@ -260,6 +260,15 @@ Baz.
          (backward-char 2)
          (expect (subed-vtt--jump-to-subtitle-end) :to-be 112)
          (expect (looking-back "^Baz.$") :to-be t)))
+      (it "handles spaces in between subtitles."
+        (with-temp-vtt-buffer
+         (insert mock-vtt-data)
+         (goto-char (point-min))
+         (re-search-forward "Foo\\.\n")
+         (replace-match "Foo.\n ")
+         (goto-char (point-min))
+         (expect (subed-vtt--jump-to-subtitle-end) :to-be 43)
+         (expect (looking-back "^Foo.$") :to-be t)))
       (it "returns nil if subtitle end cannot be found."
         (with-temp-vtt-buffer
          (expect (subed-vtt--jump-to-subtitle-end) :to-be nil)))


### PR DESCRIPTION
* tests/test-subed-vtt.el ("VTT"): Add check for spaces between subtitles.
* subed/subed-vtt.el (subed-vtt--jump-to-subtitle-end): Group properly
in case of spaces.